### PR TITLE
___UpdateInit.nb Stylesheet ref causing errors

### DIFF
--- a/ApplicationMaker/Documentation/English/ReferencePages/Symbols/___UpdateInit.nb
+++ b/ApplicationMaker/Documentation/English/ReferencePages/Symbols/___UpdateInit.nb
@@ -551,16 +551,9 @@ TaggingRules->{
     "ApplicationMaker/ref/UpdateInit"}, "SearchTextTranslated" -> ""},
 FrontEndVersion->"8.0 for Mac OS X x86 (32-bit, 64-bit Kernel) (February 23, \
 2011)",
-StyleDefinitions->Notebook[{
-   Cell[
-    StyleData[
-    StyleDefinitions -> 
-     FrontEnd`FileName[{$RootDirectory, "Users", "jmlopez", "Library", 
-        "Mathematica", "Applications", "ApplicationMaker", "FrontEnd", 
-        "Stylesheets"}, "UserReference.nb", CharacterEncoding -> "UTF-8"]]]}, 
-  Visible -> False, FrontEndVersion -> 
-  "8.0 for Mac OS X x86 (32-bit, 64-bit Kernel) (February 23, 2011)", 
-  StyleDefinitions -> "PrivateStylesheetFormatting.nb"]
+StyleDefinitions->FrontEnd`FileName[{$UserBaseDirectory, "Applications",  
+   "ApplicationMaker", "FrontEnd", "Stylesheets",}, 
+   "UserReference7.nb", CharacterEncoding -> "UTF-8"]
 ]
 (* End of Notebook Content *)
 


### PR DESCRIPTION
Really should be fixed because it causes errors(well warnings) when building package.
